### PR TITLE
feat: Profile Edit - mock API support for profile update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fitznet-react-website",
-  "version": "0.7.0",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fitznet-react-website",
-      "version": "0.7.0",
+      "version": "0.10.0",
       "dependencies": {
         "react": "^19.2.0",
         "react-dom": "^19.2.0",

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -191,6 +191,11 @@ export const logoutUser = async () => {
  * @returns {Promise<Object>} Response object with success status and updated user data
  */
 export const updateUserProfile = async (updates, token) => {
+  if (USE_MOCK_API) {
+    console.log('🎭 Using mock API for profile update');
+    return mockApi.updateProfile(updates, token);
+  }
+
   if (!token) {
     return {
       success: false,

--- a/src/services/mockApi.js
+++ b/src/services/mockApi.js
@@ -91,5 +91,25 @@ export const mockApi = {
       return false;
     }
   },
+
+  // Mock update profile endpoint
+  updateProfile: async (updates, token) => {
+    await delay(400);
+
+    if (!token) {
+      return {
+        success: false,
+        message: 'Authentication token is required',
+      };
+    }
+
+    // Simulate a successful profile update
+    return {
+      success: true,
+      message: 'Profile updated successfully',
+      username: updates.username,
+      email: updates.email,
+    };
+  },
 };
 


### PR DESCRIPTION
## Changes

### Frontend (fitz-net-website)
- Add mock API delegation in `updateUserProfile` when `VITE_USE_MOCK_API` is enabled
- Add `updateProfile` mock endpoint in `mockApi.js` for offline dev/testing

### Related
- Backend PR: https://github.com/mattlol85/fitz-net-api/pull/18