### PR TITLE
fix(ow): remove invalid CSS fragments breaking Overwatch tracker

### DIFF
--- a/src/css/OverwatchTracker.css
+++ b/src/css/OverwatchTracker.css
@@ -1,23 +1,4 @@
-﻿.role-card span {
-  margin-top: 0.2rem;
-  font-size: 0.78rem;
-  font-weight: 600;
-  text-transform: uppercase;
-.role-card strong {
-  margin-top: 0.5rem;
-  font-size: 1.6rem;
-.role-card:has(.role-card-label[data-role='dps'])::before  { background: var(--ow-role-dps); }
-.role-card:has(.role-card-label[data-role='tank'])::before { background: var(--ow-role-tank); }
-.role-card:has(.role-card-label[data-role='heals'])::before { background: var(--ow-role-heals); }
-
-.role-card-label {
-  font-size: 0.76rem;
-.role-card::before {
-  content: '';
-  padding: 1rem;
-.role-card {
-/* Î“Ã¶Ã‡Î“Ã¶Ã‡Î“Ã¶Ã‡ Fitz-Net Overwatch Tracker Î“Ã¶Ã‡Î“Ã¶Ã‡Î“Ã¶Ã‡Î“Ã¶Ã‡Î“Ã¶Ã‡Î“Ã¶Ã‡Î“Ã¶Ã‡Î“Ã¶Ã‡Î“Ã¶Ã‡Î“Ã¶Ã‡Î“Ã¶Ã‡Î“Ã¶Ã‡Î“Ã¶Ã‡Î“Ã¶Ã‡Î“Ã¶Ã‡Î“Ã¶Ã‡Î“Ã¶Ã‡Î“Ã¶Ã‡Î“Ã¶Ã‡Î“Ã¶Ã‡Î“Ã¶Ã‡Î“Ã¶Ã‡Î“Ã¶Ã‡Î“Ã¶Ã‡Î“Ã¶Ã‡Î“Ã¶Ã‡Î“Ã¶Ã‡Î“Ã¶Ã‡Î“Ã¶Ã‡Î“Ã¶Ã‡Î“Ã¶Ã‡Î“Ã¶Ã‡Î“Ã¶Ã‡Î“Ã¶Ã‡Î“Ã¶Ã‡Î“Ã¶Ã‡Î“Ã¶Ã‡Î“Ã¶Ã‡Î“Ã¶Ã‡Î“Ã¶Ã‡Î“Ã¶Ã‡Î“Ã¶Ã‡Î“Ã¶Ã‡Î“Ã¶Ã‡ */
-
+﻿
 .overwatch-tracker {
   --ow-accent:       #d35400;
   --ow-accent-hover: #a04000;
@@ -33,7 +14,7 @@
   color: var(--text-primary);
 }
 
-/* Î“Ã¶Ã‡Î“Ã¶Ã‡Î“Ã¶Ã‡ Header Î“Ã¶Ã‡Î“Ã¶Ã‡Î“Ã¶Ã‡Î“Ã¶Ã‡Î“Ã¶Ã‡Î“Ã¶Ã‡Î“Ã¶Ã‡Î“Ã¶Ã‡Î“Ã¶Ã‡Î“Ã¶Ã‡Î“Ã¶Ã‡Î“Ã¶Ã‡Î“Ã¶Ã‡Î“Ã¶Ã‡Î“Ã¶Ã‡Î“Ã¶Ã‡Î“Ã¶Ã‡Î“Ã¶Ã‡Î“Ã¶Ã‡Î“Ã¶Ã‡Î“Ã¶Ã‡Î“Ã¶Ã‡Î“Ã¶Ã‡Î“Ã¶Ã‡Î“Ã¶Ã‡Î“Ã¶Ã‡Î“Ã¶Ã‡Î“Ã¶Ã‡Î“Ã¶Ã‡Î“Ã¶Ã‡Î“Ã¶Ã‡Î“Ã¶Ã‡Î“Ã¶Ã‡Î“Ã¶Ã‡Î“Ã¶Ã‡Î“Ã¶Ã‡Î“Ã¶Ã‡Î“Ã¶Ã‡Î“Ã¶Ã‡Î“Ã¶Ã‡Î“Ã¶Ã‡Î“Ã¶Ã‡Î“Ã¶Ã‡Î“Ã¶Ã‡Î“Ã¶Ã‡Î“Ã¶Ã‡Î“Ã¶Ã‡Î“Ã¶Ã‡Î“Ã¶Ã‡Î“Ã¶Ã‡Î“Ã¶Ã‡Î“Ã¶Ã‡Î“Ã¶Ã‡Î“Ã¶Ã‡Î“Ã¶Ã‡Î“Ã¶Ã‡Î“Ã¶Ã‡Î“Ã¶Ã‡Î“Ã¶Ã‡Î“Ã¶Ã‡Î“Ã¶Ã‡Î“Ã¶Ã‡Î“Ã¶Ã‡Î“Ã¶Ã‡Î“Ã¶Ã‡Î“Ã¶Ã‡ */
+/* Header */
 
 .tracker-header,
 .leaderboard-heading,


### PR DESCRIPTION
## Problem

Commit 31b1445 accidentally prepended 18 lines of unclosed CSS rule blocks to the top of `src/css/OverwatchTracker.css`:

```css
.role-card span {
  margin-top: 0.2rem;
  ...
.role-card strong {   ← missing closing } before each new selector
  ...
.role-card {
```

These missing `}` closing braces corrupted the entire CSS cascade. The browser's error recovery kept the opening blocks unclosed, causing all subsequent rules (grid layouts, stat cards, leaderboard rows, etc.) to be misinterpreted or discarded.

## Result

The Overwatch tracker page at `/overwatch` rendered completely unstyled — no grid layout, inline stat labels, and no leaderboard row formatting.

## Fix

Removed the 18 invalid prepended lines. The correct, properly-closed `.role-card` rules already exist later in the file and are unaffected.