### PR TITLE
fix(auth): board visibility and profile color

### DIFF
--- a/src/components/EditProfile.jsx
+++ b/src/components/EditProfile.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { Navigate, useNavigate } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
+import { DEFAULT_BOARD_COLOR } from '../constants';
 import '../css/EditProfile.css';
 
 function EditProfile() {
@@ -120,11 +121,11 @@ function EditProfile() {
             <div className="board-color-display" data-testid="board-color-display">
               <span
                 className="board-color-swatch"
-                style={{ background: user?.boardColor || 'hsl(200,72%,50%)' }}
+                style={{ background: user?.boardColor || DEFAULT_BOARD_COLOR }}
                 data-testid="board-color-swatch"
               />
               <span className="board-color-label">
-                {user?.boardColor || '—'}
+                {user?.boardColor || DEFAULT_BOARD_COLOR}
               </span>
               <span className="board-color-hint">(auto-assigned, permanent)</span>
             </div>
@@ -185,4 +186,3 @@ function EditProfile() {
 }
 
 export default EditProfile;
-

--- a/src/components/EditProfile.test.jsx
+++ b/src/components/EditProfile.test.jsx
@@ -52,6 +52,7 @@ describe('EditProfile', () => {
 
     expect(screen.getByDisplayValue('testuser')).toBeInTheDocument();
     expect(screen.getByDisplayValue('test@example.com')).toBeInTheDocument();
+    expect(screen.getByText('hsl(200,72%,50%)')).toBeInTheDocument();
   });
 
   it('submits profile updates', async () => {
@@ -86,4 +87,3 @@ describe('EditProfile', () => {
     expect(screen.getByText('Profile updated successfully.')).toBeInTheDocument();
   });
 });
-

--- a/src/components/EditProfileModal.jsx
+++ b/src/components/EditProfileModal.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { useAuth } from '../contexts/AuthContext';
+import { DEFAULT_BOARD_COLOR } from '../constants';
 import '../css/EditProfileModal.css';
 
 function EditProfileModal({ isOpen, onClose, currentUser }) {
@@ -113,11 +114,11 @@ function EditProfileModal({ isOpen, onClose, currentUser }) {
             <div className="board-color-display" data-testid="board-color-display">
               <span
                 className="board-color-swatch"
-                style={{ background: currentUser?.boardColor || 'hsl(200,72%,50%)' }}
+                style={{ background: currentUser?.boardColor || DEFAULT_BOARD_COLOR }}
                 data-testid="board-color-swatch"
               />
               <span className="board-color-label">
-                {currentUser?.boardColor || '—'}
+                {currentUser?.boardColor || DEFAULT_BOARD_COLOR}
               </span>
               <span className="board-color-hint">(auto-assigned, permanent)</span>
             </div>

--- a/src/components/LiveBoard.jsx
+++ b/src/components/LiveBoard.jsx
@@ -13,6 +13,7 @@ import {
 } from '../services/liveBoardService';
 import LiveCursor from './LiveCursor';
 import BoardMessage from './BoardMessage';
+import { DEFAULT_BOARD_COLOR } from '../constants';
 import '../css/LiveBoard.css';
 
 const SNAKE_MAX_AGE         = 1500;  // ms — always-on cursor trail duration
@@ -46,7 +47,7 @@ function LiveBoard() {
   const lastCursor = useRef({ xRatio: 0, yRatio: 0 });
   const lastPaintDotRef = useRef({});  // username → last paint-dot timestamp
 
-  const ownColor = useMemo(() => user?.boardColor || 'hsl(200,72%,50%)', [user?.boardColor]);
+  const ownColor = useMemo(() => user?.boardColor || DEFAULT_BOARD_COLOR, [user?.boardColor]);
 
   // ── Helper: push a point to snake trail for a user ───────────────────────
   const pushSnakePoint = useCallback((username, xPct, yPct, color) => {
@@ -405,4 +406,3 @@ function LiveBoard() {
 }
 
 export default LiveBoard;
-

--- a/src/components/Register.test.jsx
+++ b/src/components/Register.test.jsx
@@ -1,7 +1,8 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import { BrowserRouter } from 'react-router-dom';
+import { BrowserRouter, MemoryRouter, Route, Routes } from 'react-router-dom';
 import { AuthProvider } from '../contexts/AuthContext';
+import Navbar from './Navbar.jsx';
 import Register from './Register';
 
 // Mock the API module
@@ -10,6 +11,7 @@ vi.mock('../services/api', () => ({
   loginUser: vi.fn(),
   validateToken: vi.fn(() => true),
   logoutUser: vi.fn(),
+  updateUserProfile: vi.fn(),
 }));
 
 describe('Register Component', () => {
@@ -25,6 +27,12 @@ describe('Register Component', () => {
         </AuthProvider>
       </BrowserRouter>
     );
+  };
+
+  const validToken = () => {
+    const header = btoa(JSON.stringify({ alg: 'HS384' }));
+    const payload = btoa(JSON.stringify({ exp: Math.floor(Date.now() / 1000) + 3600 }));
+    return `${header}.${payload}.sig`;
   };
 
   it('renders registration form with all required fields', () => {
@@ -137,5 +145,44 @@ describe('Register Component', () => {
       expect(createUser).toHaveBeenCalledWith('testuser', 'test@example.com', 'password123');
     });
   });
-});
 
+  it('shows The Board nav link immediately after account creation and auto-login', async () => {
+    const { createUser, loginUser } = await import('../services/api');
+    createUser.mockResolvedValueOnce({
+      success: true,
+      message: 'Account created',
+      username: 'newuser',
+      email: 'new@example.com',
+      id: '123',
+    });
+    loginUser.mockResolvedValueOnce({
+      success: true,
+      message: 'Login successful',
+      username: 'newuser',
+      email: 'new@example.com',
+      token: validToken(),
+    });
+
+    render(
+      <AuthProvider>
+        <MemoryRouter initialEntries={['/register']}>
+          <Navbar theme="light" toggleTheme={vi.fn()} />
+          <Routes>
+            <Route path="/register" element={<Register />} />
+            <Route path="/" element={<div>Home</div>} />
+          </Routes>
+        </MemoryRouter>
+      </AuthProvider>
+    );
+
+    fireEvent.change(screen.getByLabelText(/username/i), { target: { value: 'newuser' } });
+    fireEvent.change(screen.getByLabelText(/email/i), { target: { value: 'new@example.com' } });
+    fireEvent.change(screen.getByLabelText(/^password/i), { target: { value: 'password123' } });
+    fireEvent.change(screen.getByLabelText(/confirm password/i), { target: { value: 'password123' } });
+    fireEvent.click(screen.getByRole('button', { name: /create account/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('link', { name: /the board/i })).toBeInTheDocument();
+    });
+  });
+});

--- a/src/constants.js
+++ b/src/constants.js
@@ -9,6 +9,8 @@ export const API_URLS = {
   GAMERBELL: import.meta.env.VITE_GAMERBELL_URL || 'https://gamerbell.com',
 };
 
+export const DEFAULT_BOARD_COLOR = 'hsl(200,72%,50%)';
+
 // API Configurations for Status Dashboard
 export const API_CONFIGS = [
   { name: 'fitz-net-website', url: typeof window !== 'undefined' ? window.location.origin : 'http://localhost:3000', local: true },

--- a/src/contexts/AuthContext.jsx
+++ b/src/contexts/AuthContext.jsx
@@ -1,5 +1,7 @@
 import React, { createContext, useState, useEffect, useContext } from 'react';
+import { flushSync } from 'react-dom';
 import { loginUser, logoutUser, validateToken, updateUserProfile } from '../services/api';
+import { DEFAULT_BOARD_COLOR } from '../constants';
 
 // Create the AuthContext
 const AuthContext = createContext(null);
@@ -18,6 +20,12 @@ export const AuthProvider = ({ children }) => {
   const [user, setUser] = useState(null);
   const [token, setToken] = useState(null);
   const [loading, setLoading] = useState(true);
+
+  const normalizeUserData = (data = {}, fallbackUser = {}) => ({
+    username: data.username ?? fallbackUser?.username ?? '',
+    email: data.email ?? fallbackUser?.email ?? '',
+    boardColor: data.boardColor || fallbackUser?.boardColor || DEFAULT_BOARD_COLOR,
+  });
 
   const getStorage = () => {
     if (typeof window === 'undefined') return null;
@@ -61,7 +69,7 @@ export const AuthProvider = ({ children }) => {
       // Validate token before restoring session
       if (validateToken(storedToken)) {
         setToken(storedToken);
-        setUser(JSON.parse(storedUser));
+        setUser(normalizeUserData(JSON.parse(storedUser)));
       } else {
         // Token expired, clear storage
         safeRemoveItem('authToken');
@@ -79,14 +87,12 @@ export const AuthProvider = ({ children }) => {
       console.log('🔑 Login response:', response);
 
       if (response.success) {
-        const userData = {
-          username: response.username,
-          email: response.email,
-          boardColor: response.boardColor,
-        };
+        const userData = normalizeUserData(response);
 
-        setUser(userData);
-        setToken(response.token);
+        flushSync(() => {
+          setUser(userData);
+          setToken(response.token);
+        });
 
         // Persist to localStorage
         safeSetItem('authToken', response.token);
@@ -135,11 +141,7 @@ export const AuthProvider = ({ children }) => {
       const response = await updateUserProfile(updates, token);
 
       if (response.success) {
-        const updatedUserData = {
-          username: response.username,
-          email: response.email,
-          boardColor: response.boardColor ?? user?.boardColor,
-        };
+        const updatedUserData = normalizeUserData(response, user);
 
         setUser(updatedUserData);
         safeSetItem('authUser', JSON.stringify(updatedUserData));


### PR DESCRIPTION
## Summary
- commit auth state synchronously after auto-login so newly registered users immediately see authenticated nav links like The Board
- normalize missing boardColor values to a shared default across auth restore, login, profile update, profile UI, and Live Board
- add regression coverage for immediate The Board visibility after registration and default profile color display

## Verification
- npm test -- --run
- npm run build