### PR TITLE
fix(nav): prevent live board obstruction

### DIFF
--- a/AGENT_INSTRUCTIONS.md
+++ b/AGENT_INSTRUCTIONS.md
@@ -1,0 +1,17 @@
+# Fitz-Net Website Agent Instructions
+
+## Commit Messages
+
+Use conventional commit messages in this format:
+
+```text
+fix(subject): content here
+feat(subject): content here
+chore(subject): content here
+```
+
+Choose the type that matches the change:
+
+- `fix` for bug fixes
+- `feat` for new user-facing behavior
+- `chore` for maintenance, tooling, and documentation changes

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useLayoutEffect, useRef } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import logo from '../img/FN_Logo_Straight.png';
 import ThemeToggle from './ThemeToggle.jsx';
@@ -8,6 +8,35 @@ import '../css/Navbar.css';
 function Navbar({ theme, toggleTheme }) {
   const { user, logout, isAuthenticated } = useAuth();
   const navigate = useNavigate();
+  const navRef = useRef(null);
+  const authenticated = isAuthenticated();
+
+  useLayoutEffect(() => {
+    const updateNavbarHeight = () => {
+      const height = navRef.current?.getBoundingClientRect().height;
+
+      if (height) {
+        document.documentElement.style.setProperty('--navbar-height', `${Math.ceil(height)}px`);
+      }
+    };
+
+    updateNavbarHeight();
+
+    const resizeObserver = typeof ResizeObserver !== 'undefined'
+      ? new ResizeObserver(updateNavbarHeight)
+      : null;
+
+    if (resizeObserver && navRef.current) {
+      resizeObserver.observe(navRef.current);
+    }
+
+    window.addEventListener('resize', updateNavbarHeight);
+
+    return () => {
+      resizeObserver?.disconnect();
+      window.removeEventListener('resize', updateNavbarHeight);
+    };
+  }, []);
 
   const handleLogout = async () => {
     await logout();
@@ -15,8 +44,8 @@ function Navbar({ theme, toggleTheme }) {
   };
 
   return (
-    <nav>
-      <ul>
+    <nav ref={navRef} className="site-nav">
+      <ul className={`site-nav-list ${authenticated ? 'site-nav-list--authenticated' : 'site-nav-list--guest'}`}>
         <li>
           <Link to="/" className="logo-link">
             <img src={logo} alt="Fitz-Net Logo" className="logo-img" />
@@ -28,7 +57,7 @@ function Navbar({ theme, toggleTheme }) {
         <li>
           <Link to="/status">Status</Link>
         </li>
-        {isAuthenticated() && (
+        {authenticated && (
           <>
             <li>
               <Link to="/overwatch">Overwatch Tracker</Link>
@@ -42,7 +71,7 @@ function Navbar({ theme, toggleTheme }) {
           </>
         )}
         <li className="nav-spacer"></li>
-        {isAuthenticated() ? (
+        {authenticated ? (
           <>
             <li className="user-info">
               <Link to="/profile" className="username username-clickable">

--- a/src/components/Navbar.test.jsx
+++ b/src/components/Navbar.test.jsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react';
+import { afterEach } from 'vitest';
 import { BrowserRouter } from 'react-router-dom';
 import { AuthProvider } from '../contexts/AuthContext';
 import Navbar from './Navbar.jsx';
@@ -21,6 +22,11 @@ describe('Navbar Component', () => {
     // Reset mocks before each test
     vi.clearAllMocks();
     localStorageMock.getItem.mockReturnValue(null);
+    document.documentElement.style.removeProperty('--navbar-height');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   const renderNavbar = () => {
@@ -34,10 +40,12 @@ describe('Navbar Component', () => {
   };
 
   test('renders navigation links', () => {
-    renderNavbar();
+    const { container } = renderNavbar();
 
     const aboutLink = screen.getByText(/About/i);
     expect(aboutLink).toBeInTheDocument();
+    expect(container.querySelector('.site-nav-list--guest')).toBeInTheDocument();
+    expect(container.querySelector('.nav-spacer')).toBeInTheDocument();
   });
 
   test('renders logo image', () => {
@@ -66,5 +74,23 @@ describe('Navbar Component', () => {
 
     const themeToggle = screen.getByRole('button', { name: /Toggle theme/i });
     expect(themeToggle).toBeInTheDocument();
+  });
+
+  test('updates navbar height CSS variable from rendered height', () => {
+    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue({
+      height: 96,
+      width: 800,
+      top: 0,
+      right: 800,
+      bottom: 96,
+      left: 0,
+      x: 0,
+      y: 0,
+      toJSON: () => {},
+    });
+
+    renderNavbar();
+
+    expect(document.documentElement.style.getPropertyValue('--navbar-height')).toBe('96px');
   });
 });

--- a/src/css/Navbar.css
+++ b/src/css/Navbar.css
@@ -66,30 +66,35 @@
   max-height: 50px;
 }
 
-nav {
+.site-nav {
   background-color: var(--nav-bg);
-  transition: background-color 0.3s ease;
+  transition: background-color 0.3s ease, box-shadow 0.3s ease;
+  position: relative;
+  z-index: 30;
 }
 
-nav ul {
+.site-nav-list {
   list-style: none;
   display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem 1rem;
   margin: 0;
   padding: 0;
   align-items: center;
 }
 
-nav ul li {
-  margin-right: 20px;
-}
-
-nav ul li:last-child {
+.site-nav-list > li {
   margin-right: 0;
+  flex: 0 0 auto;
 }
 
 .nav-spacer {
-  flex-grow: 1;
-  margin-right: 0 !important;
+  flex: 1 1 auto;
+  min-width: 1rem;
+}
+
+.site-nav-list--guest .nav-spacer {
+  margin-left: auto;
 }
 
 .user-info {
@@ -105,6 +110,9 @@ nav ul li:last-child {
   background: rgba(0, 123, 255, 0.1);
   border-radius: 6px;
   white-space: nowrap;
+  max-width: min(18rem, 100%);
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .username-clickable {
@@ -156,4 +164,14 @@ nav ul li:last-child {
 
 [data-theme="dark"] .logout-button:hover {
   background: #b21f2d;
+}
+
+@media (max-width: 900px) {
+  .site-nav-list--authenticated .nav-spacer {
+    display: none;
+  }
+
+  .site-nav-list--authenticated {
+    justify-content: center;
+  }
 }


### PR DESCRIPTION
## Summary
- add agent instructions documenting the required conventional commit message format
- measure the rendered navbar height and publish it to --navbar-height so fixed Live Board content starts below multi-row nav layouts
- make authenticated nav wrapping responsive while keeping logged-out Login / Sign Up actions aligned on the right
- add regression coverage for updating the navbar height CSS variable and guest nav structure

## Root cause
The Live Board uses a fixed canvas positioned with top: var(--navbar-height), but --navbar-height was hard-coded to 60px. Authenticated nav content wraps taller than that at narrower widths, so the board canvas began underneath the navbar and visually obstructed the controls. A first pass also hid the spacer globally on smaller screens, which moved guest Login / Sign Up actions left; the spacer behavior is now scoped by auth state.

## Commit format
This PR now includes AGENT_INSTRUCTIONS.md with the required format:
- fix(subject): content here
- feat(subject): content here
- chore(subject): content here

## Verification
- npm test -- --run
- npm run build
- npm test -- --run src/components/Navbar.test.jsx
- Playwright screenshot smoke check at 964x330 and 390x720