### PR TITLE
feat(live-board): increase message persistence to 24 hours

### DIFF
--- a/src/services/liveBoardService.js
+++ b/src/services/liveBoardService.js
@@ -7,7 +7,7 @@
  */
 import { Client } from '@stomp/stompjs';
 
-export const FADE_DURATION_MS = 90_000;
+export const FADE_DURATION_MS = 86_400_000; // 24 hours
 
 const USE_MOCK = import.meta.env.VITE_USE_MOCK_API === 'true';
 

--- a/src/services/liveBoardService.test.js
+++ b/src/services/liveBoardService.test.js
@@ -33,8 +33,8 @@ describe('liveBoardService', () => {
     disconnect();
   });
 
-  test('FADE_DURATION_MS is 90000', () => {
-    expect(FADE_DURATION_MS).toBe(90_000);
+  test('FADE_DURATION_MS is 86400000 (24 hours)', () => {
+    expect(FADE_DURATION_MS).toBe(86_400_000);
   });
 
   test('subscribeCursors registers a callback and returns an unsubscribe function', () => {


### PR DESCRIPTION
Increases `FADE_DURATION_MS` from 90 seconds to 24 hours (86,400,000 ms) so Live Board messages remain visible for a full day instead of fading out after 90 seconds.