### PR TITLE
feat(auth): Forgot password / reset password UI flow

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,6 +10,8 @@ import Footer from './components/Footer.jsx';
 import Login from './components/Login.jsx';
 import Register from './components/Register.jsx';
 import EditProfile from './components/EditProfile.jsx';
+import ForgotPassword from './components/ForgotPassword.jsx';
+import ResetPassword from './components/ResetPassword.jsx';
 import WebSocketButton from './components/WebSocketButton.jsx';
 import StatusDashboard from './components/StatusDashboard.jsx';
 import OverwatchTracker from './components/OverwatchTracker.jsx';
@@ -47,6 +49,8 @@ function App() {
             <Route path="/liveboard" element={<LiveBoard />} />
             <Route path="/login" element={<Login />} />
             <Route path="/register" element={<Register />} />
+            <Route path="/forgot-password" element={<ForgotPassword />} />
+            <Route path="/reset-password" element={<ResetPassword />} />
             <Route path="/profile" element={<EditProfile />} />
             <Route path="*" element={<NoPage />} />
           </Routes>

--- a/src/components/ForgotPassword.jsx
+++ b/src/components/ForgotPassword.jsx
@@ -1,0 +1,77 @@
+import React, { useState } from 'react';
+import { Link } from 'react-router-dom';
+import { forgotPassword } from '../services/api';
+import '../css/Login.css';
+
+function ForgotPassword() {
+  const [email, setEmail] = useState('');
+  const [status, setStatus] = useState(null);
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setLoading(true);
+    setStatus(null);
+
+    const result = await forgotPassword(email);
+    setLoading(false);
+    setStatus({ success: result.success, message: result.message });
+  };
+
+  return (
+    <div className="login-container">
+      <div className="login-card">
+        <h2 className="login-title">Forgot Password</h2>
+
+        {status?.success ? (
+          <div>
+            <p style={{ color: 'var(--text-primary)', textAlign: 'center', marginBottom: '1.5rem' }}>
+              {status.message}
+            </p>
+            <div className="login-help">
+              <p>
+                <Link to="/login" className="register-link">Back to Login</Link>
+              </p>
+            </div>
+          </div>
+        ) : (
+          <form onSubmit={handleSubmit} className="login-form">
+            <p style={{ color: 'var(--text-secondary, #666)', fontSize: '0.95rem', margin: 0 }}>
+              Enter your account email and we'll send you a reset link.
+            </p>
+
+            <div className="form-group">
+              <label htmlFor="email">Email</label>
+              <input
+                type="email"
+                id="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                placeholder="Enter your email"
+                disabled={loading}
+                required
+                autoComplete="email"
+              />
+            </div>
+
+            {status && !status.success && (
+              <div className="error-message">{status.message}</div>
+            )}
+
+            <button type="submit" className="login-button" disabled={loading || !email}>
+              {loading ? 'Sending...' : 'Send Reset Link'}
+            </button>
+
+            <div className="login-help">
+              <p>
+                Remember your password? <Link to="/login" className="register-link">Login</Link>
+              </p>
+            </div>
+          </form>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default ForgotPassword;

--- a/src/components/Login.jsx
+++ b/src/components/Login.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import {Link, useNavigate} from 'react-router-dom';
+import {Link, useLocation, useNavigate} from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
 import '../css/Login.css';
 
@@ -9,7 +9,9 @@ function Login() {
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
   const navigate = useNavigate();
+  const location = useLocation();
   const { login } = useAuth();
+  const successMessage = location.state?.message;
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -65,6 +67,12 @@ function Login() {
             />
           </div>
 
+          {successMessage && (
+            <div style={{ background: '#efe', border: '1px solid #6c6', color: '#363', padding: '0.75rem', borderRadius: '6px', fontSize: '0.9rem', textAlign: 'center' }}>
+              {successMessage}
+            </div>
+          )}
+
           {error && <div className="error-message">{error}</div>}
 
           <button type="submit" className="login-button" disabled={loading}>
@@ -75,6 +83,9 @@ function Login() {
         <div className="login-help">
           <p>
             Don't have an account? <Link to="/register" className="register-link">Sign up</Link>
+          </p>
+          <p>
+            <Link to="/forgot-password" className="register-link">Forgot your password?</Link>
           </p>
         </div>
       </div>

--- a/src/components/ResetPassword.jsx
+++ b/src/components/ResetPassword.jsx
@@ -1,0 +1,110 @@
+import React, { useState } from 'react';
+import { Link, useNavigate, useSearchParams } from 'react-router-dom';
+import { resetPassword } from '../services/api';
+import '../css/Login.css';
+
+function ResetPassword() {
+  const [searchParams] = useSearchParams();
+  const token = searchParams.get('token');
+  const navigate = useNavigate();
+
+  const [newPassword, setNewPassword] = useState('');
+  const [confirm, setConfirm] = useState('');
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  if (!token) {
+    return (
+      <div className="login-container">
+        <div className="login-card">
+          <h2 className="login-title">Invalid Link</h2>
+          <p style={{ color: 'var(--text-secondary, #666)', textAlign: 'center' }}>
+            This reset link is missing or malformed.
+          </p>
+          <div className="login-help">
+            <p>
+              <Link to="/forgot-password" className="register-link">Request a new reset link</Link>
+            </p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setError('');
+
+    if (newPassword !== confirm) {
+      setError('Passwords do not match.');
+      return;
+    }
+
+    if (newPassword.length < 8) {
+      setError('Password must be at least 8 characters.');
+      return;
+    }
+
+    setLoading(true);
+    const result = await resetPassword(token, newPassword);
+    setLoading(false);
+
+    if (result.success) {
+      navigate('/login', { state: { message: 'Password reset! You can now log in.' } });
+    } else {
+      setError(result.message);
+    }
+  };
+
+  return (
+    <div className="login-container">
+      <div className="login-card">
+        <h2 className="login-title">Reset Password</h2>
+
+        <form onSubmit={handleSubmit} className="login-form">
+          <div className="form-group">
+            <label htmlFor="newPassword">New Password</label>
+            <input
+              type="password"
+              id="newPassword"
+              value={newPassword}
+              onChange={(e) => setNewPassword(e.target.value)}
+              placeholder="New password (min. 8 characters)"
+              disabled={loading}
+              required
+              autoComplete="new-password"
+            />
+          </div>
+
+          <div className="form-group">
+            <label htmlFor="confirm">Confirm Password</label>
+            <input
+              type="password"
+              id="confirm"
+              value={confirm}
+              onChange={(e) => setConfirm(e.target.value)}
+              placeholder="Confirm new password"
+              disabled={loading}
+              required
+              autoComplete="new-password"
+            />
+          </div>
+
+          {error && <div className="error-message">{error}</div>}
+
+          <button type="submit" className="login-button" disabled={loading}>
+            {loading ? 'Resetting...' : 'Reset Password'}
+          </button>
+
+          <div className="login-help">
+            <p>
+              <Link to="/login" className="register-link">Back to Login</Link>
+            </p>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+export default ResetPassword;

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -485,12 +485,53 @@ export const getOverwatchHistory = async (token, playerId) => {
   }
 };
 
+export const forgotPassword = async (email) => {
+  try {
+    const url = `${API_BASE_URL}/user/forgot-password`;
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
+      mode: 'cors',
+      credentials: 'omit',
+      body: JSON.stringify({ email }),
+    });
+    const data = await parseResponseData(response);
+    return { success: response.ok, message: data.message || 'Check your email for a reset link.' };
+  } catch (error) {
+    console.error('Forgot password error:', error);
+    return { success: false, message: 'Network error. Please try again.' };
+  }
+};
+
+export const resetPassword = async (token, newPassword) => {
+  try {
+    const url = `${API_BASE_URL}/user/reset-password`;
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
+      mode: 'cors',
+      credentials: 'omit',
+      body: JSON.stringify({ token, newPassword }),
+    });
+    const data = await parseResponseData(response);
+    if (!response.ok) {
+      return { success: false, message: data.message || 'Invalid or expired reset link.' };
+    }
+    return { success: true, message: data.message || 'Password reset successfully.' };
+  } catch (error) {
+    console.error('Reset password error:', error);
+    return { success: false, message: 'Network error. Please try again.' };
+  }
+};
+
 export const api = {
   createUser,
   loginUser,
   validateToken,
   logoutUser,
   updateUserProfile,
+  forgotPassword,
+  resetPassword,
   searchOverwatchPlayers,
   saveOverwatchProfile,
   getOverwatchProfile,


### PR DESCRIPTION
## Summary

Adds the complete client-side password reset flow, backed by the new API endpoints in [fitz-net-api #31](https://github.com/mattlol85/fitz-net-api/pull/31).

- **`/forgot-password`** page — user enters their email; on success shows "check your email" message
- **`/reset-password?token=...`** page — user enters and confirms new password; on success redirects to `/login` with a success banner
- **Login page** — "Forgot your password?" link added below the form; shows success banner after a reset redirect
- **`api.js`** — `forgotPassword(email)` and `resetPassword(token, newPassword)` service functions added
- **`App.jsx`** — two new public routes registered

## New Files

| File | Purpose |
|------|---------|
| `src/components/ForgotPassword.jsx` | Email input form; shows confirmation on success |
| `src/components/ResetPassword.jsx` | New password form; reads `?token=` from URL; handles invalid/expired link |

## Modified Files

| File | Change |
|------|--------|
| `src/services/api.js` | Add `forgotPassword` and `resetPassword` |
| `src/App.jsx` | Register `/forgot-password` and `/reset-password` routes |
| `src/components/Login.jsx` | Add "Forgot your password?" link, show reset success banner |

## UI Notes

- Reuses existing `Login.css` classes (`login-container`, `login-card`, `login-button`, `error-message`, etc.) — no new CSS needed
- Invalid/missing reset token shows a fallback card with a link to request a new one
- Password mismatch and minimum length validated client-side before API call

## Test Plan

- [ ] All 114 existing tests pass (`npm test -- --run`)
- [ ] Navigate to `/login` → "Forgot your password?" link is visible
- [ ] `/forgot-password` → enter registered email → success message shown
- [ ] Click email link → lands on `/reset-password?token=...`
- [ ] Enter matching passwords ≥ 8 chars → submit → redirected to `/login` with success banner
- [ ] Mismatched passwords → inline error shown
- [ ] `/reset-password` with no `?token=` → fallback "Invalid Link" card shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)