### PR TITLE
feat(observability): add website telemetry signals

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ COPY nginx.conf /etc/nginx/conf.d/default.conf
 COPY --from=builder /app/build /usr/share/nginx/html
 
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-  CMD wget --no-verbose --tries=1 --spider http://localhost:80/ || exit 1
+  CMD wget --no-verbose --tries=1 --spider http://localhost:80/health || exit 1
 
 EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]

--- a/README.md
+++ b/README.md
@@ -99,6 +99,15 @@ The included `docker-compose.yml` supports running multiple services together. S
 - Running with other services
 - Production deployment
 
+### 📈 Operational Telemetry
+
+The production Nginx layer now exposes two lightweight operational signals:
+
+- **Structured JSON access logs to stdout/stderr** for Loki-friendly dashboards covering request rate, status codes, request latency, and upstream API latency/errors.
+- **`/nginx_status`** for basic live Nginx connection telemetry (`active`, `reading`, `writing`, `waiting`) from private network ranges and localhost.
+
+This keeps telemetry low-risk and easy to operate without adding a frontend analytics subsystem.
+
 ## 🔐 Environment Variables
 
 The application requires the following environment variables to be configured in a `.env` file:

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,8 +1,28 @@
+log_format fitznet_json escape=json
+    '{'
+        '"time":"$time_iso8601",'
+        '"remote_addr":"$remote_addr",'
+        '"x_forwarded_for":"$proxy_add_x_forwarded_for",'
+        '"request_method":"$request_method",'
+        '"request_uri":"$request_uri",'
+        '"status":$status,'
+        '"body_bytes_sent":$body_bytes_sent,'
+        '"request_time":$request_time,'
+        '"upstream_addr":"$upstream_addr",'
+        '"upstream_status":"$upstream_status",'
+        '"upstream_response_time":"$upstream_response_time",'
+        '"referrer":"$http_referer",'
+        '"user_agent":"$http_user_agent"'
+    '}';
+
 server {
     listen 80;
     server_name _;
     root /usr/share/nginx/html;
     index index.html;
+
+    access_log /dev/stdout fitznet_json;
+    error_log /dev/stderr warn;
 
     # Gzip compression
     gzip on;
@@ -34,16 +54,46 @@ server {
         proxy_cache_bypass $http_upgrade;
     }
 
+    # Fitz-Net API actuator proxy
+    location /actuator-fitz/ {
+        proxy_pass https://api.fitznet.doomdns.org/actuator/;
+        proxy_ssl_server_name on;
+        proxy_set_header Host api.fitznet.doomdns.org;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # Gamerbell actuator proxy
+    location /actuator-gamerbell/ {
+        proxy_pass https://gamerbell.fitznet.doomdns.org/actuator/;
+        proxy_ssl_server_name on;
+        proxy_set_header Host gamerbell.fitznet.doomdns.org;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
     # SPA fallback - all routes go to index.html
     location / {
         try_files $uri $uri/ /index.html;
     }
 
+    # Nginx connection telemetry for lightweight operational dashboards
+    location = /nginx_status {
+        access_log off;
+        stub_status;
+        allow 127.0.0.1;
+        allow 10.0.0.0/8;
+        allow 172.16.0.0/12;
+        allow 192.168.0.0/16;
+        deny all;
+    }
+
     # Health check endpoint
-    location /health {
+    location = /health {
         access_log off;
         return 200 "healthy\n";
         add_header Content-Type text/plain;
     }
 }
-


### PR DESCRIPTION
Add structured Nginx JSON logs, lightweight website status endpoints (`/actuator-fitz/`, `/actuator-gamerbell/`, `/nginx_status`, and `/health`), and the container wiring needed for Grafana/Loki dashboard support.